### PR TITLE
[REFACTOR] 로그인 버튼을 Menu 컴포넌트의 <ul> 태그 리스트로 이동

### DIFF
--- a/src/components/Header/DesktopMenu.tsx
+++ b/src/components/Header/DesktopMenu.tsx
@@ -1,11 +1,9 @@
-import LoginButton from './LoginButton';
 import Menu from './Menu';
 
 export default function DesktopMenu() {
   return (
     <div className="flex items-center gap-6 lg:hidden">
       <Menu className={{ ul: 'flex items-center gap-4' }} />
-      <LoginButton />
     </div>
   );
 }

--- a/src/components/Header/Menu.tsx
+++ b/src/components/Header/Menu.tsx
@@ -7,7 +7,7 @@ import LoginButton from './LoginButton';
 
 type Props = {
   onClick?: () => void;
-  className: { ul: string; li?: string };
+  className: { ul: string; li?: string; buttonStyle?: string };
 };
 
 export default function Menu({ onClick, className }: Props) {
@@ -25,7 +25,7 @@ export default function Menu({ onClick, className }: Props) {
           </Link>
         </li>
       ))}
-      <li>
+      <li className={className.buttonStyle}>
         <LoginButton onClick={onClick} />
       </li>
     </ul>

--- a/src/components/Header/Menu.tsx
+++ b/src/components/Header/Menu.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { navbarList } from './Navbar';
 import { usePathname } from 'next/navigation';
+import LoginButton from './LoginButton';
 
 type Props = {
   onClick?: () => void;
@@ -24,6 +25,9 @@ export default function Menu({ onClick, className }: Props) {
           </Link>
         </li>
       ))}
+      <li>
+        <LoginButton onClick={onClick} />
+      </li>
     </ul>
   );
 }

--- a/src/components/Header/MobileAside.tsx
+++ b/src/components/Header/MobileAside.tsx
@@ -13,7 +13,11 @@ export default function MobileAside({ isOpenMenu, onClick }: Props) {
     >
       <CloseButton onClick={onClick} />
       <Menu
-        className={{ ul: 'p-8 space-y-6', li: 'pb-1 border-b border-gray-200' }}
+        className={{
+          ul: 'flex flex-col p-8 space-y-6',
+          li: 'pb-1 border-b border-gray-200',
+          buttonStyle: 'self-center',
+        }}
         onClick={onClick}
       />
     </div>

--- a/src/components/Header/MobileAside.tsx
+++ b/src/components/Header/MobileAside.tsx
@@ -1,4 +1,3 @@
-import LoginButton from './LoginButton';
 import Menu from './Menu';
 import CloseButton from './CloseButton';
 
@@ -17,7 +16,6 @@ export default function MobileAside({ isOpenMenu, onClick }: Props) {
         className={{ ul: 'p-8 space-y-6', li: 'pb-1 border-b border-gray-200' }}
         onClick={onClick}
       />
-      <LoginButton onClick={onClick} />
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

close #20 

## 🛠️ 작업 내용

- [x] DesktopMenu, MobileAside 안에 있는 공통으로 있는 LoginButton을 menu 컴포넌트의 ul 태그 리스트로 이동