### PR TITLE
[FIX] Header 컴포넌트의 a 태그를 Link 태그로 변경

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,13 +1,14 @@
+import Link from 'next/link';
 import Navbar from './Navbar';
 
 export default function Header() {
   return (
     <header className="sticky top-0 left-0 flex justify-center items-center w-full h-10 px-12 py-8 shadow-base rounded-full bg-white lg:px-6 lg:py-7">
       <div className="flex justify-between items-center w-full max-w-5xl">
-        <a href="/" className="text-3xl font-bold">
+        <Link href="/" className="text-3xl font-bold">
           {/* TODO: 로고 변경 */}
           멍글멍글
-        </a>
+        </Link>
         <Navbar />
       </div>
     </header>


### PR DESCRIPTION
## #️⃣ 관련 이슈

close #28  

## 🛠️ 작업 내용

- [x] Header 컴포넌트의 a 태그를 Link 태그로 변경
