### PR TITLE
[FIX] 글 상세 페이지 내용 들여쓰기 안 되는 버그

### DIFF
--- a/src/components/Board/postDetail/PostDetailContent.tsx
+++ b/src/components/Board/postDetail/PostDetailContent.tsx
@@ -77,7 +77,7 @@ export default function PostDetailContent({
             </div>
           </div>
         </div>
-        <p className="py-6 text-xl break-words">{content}</p>
+        <pre className="py-6 text-xl whitespace-pre-wrap">{content}</pre>
         {contentImage && (
           <Image
             src={contentImage}


### PR DESCRIPTION
## #️⃣ 관련 이슈

close #77 

## 🛠️ 작업 내용

- [x] 글 콘텐츠 나타내는 태그 p 태그에서 pre 태그로 변경
