### PR TITLE
[FIX] 메인페이지 게시판 글 목록 컨테이너 비율대로 줄어들지 않는 버그 수정

### DIFF
--- a/src/components/main/boardCard/BoardCard.tsx
+++ b/src/components/main/boardCard/BoardCard.tsx
@@ -20,7 +20,7 @@ export default async function BoardCard({ category, title, calssName }: Props) {
 
   return (
     <article
-      className={`grow basis-1 p-4 space-y-3 rounded-xl shadow-base transition-all hover:scale-105 ${calssName}`}
+      className={`flex-1 min-w-0 p-4 space-y-3 rounded-xl shadow-base transition-all ${calssName}`}
     >
       <div className="flex justify-between items-center">
         <span className="md:text-sm text-md font-semibold">{title}</span>


### PR DESCRIPTION
## #️⃣ 관련 이슈

close #101 

## 🛠️ 작업 내용

- [x] 메인페이지 게시판 글 목록 컨테이너 css 수정

📷 스크린샷

![스크린샷 2024-05-30 오전 3 45 54](https://github.com/JiiHong/meong-geul-meong-geul/assets/102526510/ad6234f6-02b7-440f-8be2-4a24bfeb440e)
