### PR TITLE
[FIX] 프로필 사진 없는 상태에서 댓글 안 써지는 버그

### DIFF
--- a/src/components/Board/comments/CommentForm.tsx
+++ b/src/components/Board/comments/CommentForm.tsx
@@ -52,8 +52,9 @@ export default function CommentForm({
       uid,
       category,
       createdAt: createTime(),
-      userImage: profileImage,
     };
+    profileImage && (comment.userImage = profileImage);
+
     const newComment = replyId
       ? { ...comment, replyId, level: level! + 1 }
       : comment;


### PR DESCRIPTION
## #️⃣ 관련 이슈

close #113 

## 🛠️ 작업 내용

- [x]  댓글 등록할 때 userImage가 있을 때만 속성에 추가해서 업로드